### PR TITLE
Remove bankAccountServiceMapping create action

### DIFF
--- a/data/hr/ACCESSCONTROL-ACTIONS-TEST/actions-test.json
+++ b/data/hr/ACCESSCONTROL-ACTIONS-TEST/actions-test.json
@@ -3304,18 +3304,6 @@
       "rightIcon": ""
     },
     {
-      "id": 1586,
-      "name": "bankAccountServiceMapping create",
-      "url": "/collection-services/bankAccountServiceMapping/_create",
-      "displayName": "BankAccountServiceMapping Create",
-      "orderNumber": 1,
-      "parentModule": null,
-      "enabled": false,
-      "serviceCode": "collection-masters",
-      "code": "collection-masters.bankAccountServiceMapping",
-      "path": ""
-    },
-    {
       "id": 1587,
       "name": "bankAccountServiceMapping search",
       "url": "/collection-services/bankAccountServiceMapping/_search",


### PR DESCRIPTION
Removed the 'bankAccountServiceMapping create' action from the actions-test.json file.